### PR TITLE
Fix action type alias bug

### DIFF
--- a/app/constants/typeAliases.js
+++ b/app/constants/typeAliases.js
@@ -1,7 +1,14 @@
 // @flow
 import ChannelType from '../dataTypes/channelType';
 
-export type Action = {
+export type Action = ActionWithPayload | ActionWithoutPayload;
+
+type ActionWithPayload = {
+  type: string,
+  payload: any
+};
+
+type ActionWithoutPayload = {
   type: string,
   payload?: any
 };

--- a/app/reducers/accessToken.js
+++ b/app/reducers/accessToken.js
@@ -16,8 +16,6 @@ export default function accessToken(state: AccessTokenState = initialState, { ty
         isFetching: true
       };
     case actionTypes.RECEIVE_ACCESS_TOKEN:
-      if (!payload) return state;
-
       return {
         ...state,
         accessToken: payload,

--- a/app/reducers/channelList.js
+++ b/app/reducers/channelList.js
@@ -22,7 +22,7 @@ export default function channelList(state: ChannelListState = initialState, { ty
     case actionTypes.RECEIVE_CHANNELS:
       return {
         ...state,
-        channels: !payload ? [] : payload.map(json => ChannelType.from(json)),
+        channels: payload.map(item => ChannelType.from(item)),
         isFetching: false,
         error: false
       };

--- a/app/reducers/searchBar.js
+++ b/app/reducers/searchBar.js
@@ -14,7 +14,7 @@ export default function searchBar(state: SearchBarState = initialState, { type, 
       return {
         ...state,
         disabled: false,
-        placeholder: !payload ? 'Search' : `Search ${payload}`
+        placeholder: `Search ${payload}`
       };
     default:
       return state;

--- a/app/reducers/status.js
+++ b/app/reducers/status.js
@@ -11,9 +11,6 @@ const initialState = {
 export default function status(state: StatusState = initialState, { type, payload }: Action): StatusState {
   switch (type) {
     case actionTypes.UPDATE_STATUS:
-      if (!payload) {
-        return state;
-      }
       return {
         title: payload.title,
         thumbnail: payload.thumbnail


### PR DESCRIPTION
The Action type alias caused an unexpected flow type error due to the optional payload argument. Changing it to a union type accounts for both possible Action types.