### PR TITLE
Removed set aspect ratio

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -62,13 +62,12 @@ app.on('ready', async () => {
 
   mainWindow = new BrowserWindow({
     show: false,
-    width: 1038,
-    height: 584,
-    minWidth: 1038,
-    minHeight: 584
+    useContentSize: true,
+    width: 999,
+    height: 562,
+    minWidth: 999,
+    minHeight: 562
   });
-
-  mainWindow.setAspectRatio(16 / 9);
 
   mainWindow.loadURL(`file://${__dirname}/app.html`);
 


### PR DESCRIPTION
<!--
Hi there! Thank you for submitting a PR!

To assist whoever reviews your PR, it'd be extremely helpful for you to list whether your PR is ready to be merged,
if there's anything left to do, and if there are any related PRs.

Happy contributing!
-->
It was decided that removing set aspect ratio would be best. This fixes #55.

During testing, I noticed that when set aspect ratio was included it was possible to resize the window smaller than the minimum dimensions provided. That's an Electron bug, not a Channels bug.
  